### PR TITLE
Add package.json postinstall & buildpack hook for phoenix.digest

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: MIX_ENV=$MIX_ENV mix phoenix.server

--- a/elixir_buildpack.config
+++ b/elixir_buildpack.config
@@ -4,9 +4,6 @@ erlang_version=17.5
 # Elixir version
 elixir_version=1.0.4
 
-# Rebar version
-rebar_version=(tag 2.2.0)
-
 # Do dependencies have to be built from scratch on every deploy?
 always_build_deps=false
 
@@ -17,4 +14,4 @@ always_rebuild=false
 config_vars_to_export=(DATABASE_URL)
 
 # A command to run right after compiling the app
-post_compile="pwd"
+post_compile="mix phoenix.digest"

--- a/package.json
+++ b/package.json
@@ -9,5 +9,9 @@
     "javascript-brunch": ">= 1.0 < 1.8",
     "sass-brunch": "^1.8.10",
     "uglify-js-brunch": ">= 1.0 < 1.8"
+  },
+
+  "scripts": {
+    "postinstall": "brunch build --production"
   }
 }


### PR DESCRIPTION
Once you create a Heroku app using the Elixir buildpack, run this command:

```
heroku buildpacks:add --index 1 https://github.com/heroku/heroku-buildpack-nodejs
```

Also add a Heroku database addon if you are using postgres. By default the Elixir buidpack doesn't add it.

This will add the nodejs buildpack as the first buildpack thereby providing nodejs to the app. I'm right now making changes to make stuff easier for Phoenix usage. But for now, this PR should help you deploy to Heroku without problems.

P.S: I removed the rebar version because it isn't necessary. Infact most config vars in the buildpack config file are not necessary.
